### PR TITLE
Changed req.Header.Set(). Was previously set to text/csv

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,7 +122,7 @@ func (c *Client) getCSV(path string, query url.Values, f func(header, record []s
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Accept", "text/csv")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3")
 
 	// Send the HTTP request.
 	resp, err := c.client.Do(req)


### PR DESCRIPTION
The header was set to "text/csv". This was causing the following error from alphavantage.co: 
"detail": "Could not satisfy the request Accept header.

I therefore sent the request manually and copied the header that the server accepted and put this into the source code which then allowed the request to go through and get accepted. 